### PR TITLE
Configure sanity client apiVersion if supported

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,3 +1,11 @@
 import _client from 'part:@sanity/base/client';
-const client = _client as import('@sanity/client').SanityClient;
+const sanityClient = _client as import('@sanity/client').SanityClient;
+let client = sanityClient
+
+if (typeof sanityClient.withConfig === 'function') {
+  client = sanityClient.withConfig({
+    apiVersion: "v1"
+  })
+}
+
 export default client;

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,7 @@ let client = sanityClient
 
 if (typeof sanityClient.withConfig === 'function') {
   client = sanityClient.withConfig({
-    apiVersion: "v1"
+    apiVersion: "1"
   })
 }
 


### PR DESCRIPTION
This silences console warnings on newer Sanity Studio versions. Set to version 1 here to avoid any functional changes since api was updated to v2021-03-25 in march.
