### PR TITLE
Bugfix: Avoid undefined value in <SanityPreview>

### DIFF
--- a/src/cell/index.tsx
+++ b/src/cell/index.tsx
@@ -52,7 +52,9 @@ function Cell({ field, value }: Props) {
     default: {
       return (
         <td key={field.name}>
-          <SanityPreview type={field.type} layout="default" value={value} />
+          {value && (
+            <SanityPreview type={field.type} layout="default" value={value} />
+          )}
         </td>
       );
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,3 +1,11 @@
 import _client from 'part:@sanity/base/client';
-const client = _client as import('@sanity/client').SanityClient;
+const sanityClient = _client as import('@sanity/client').SanityClient;
+let client = sanityClient
+
+if (typeof sanityClient.withConfig === 'function') {
+  client = sanityClient.withConfig({
+    apiVersion: "v1"
+  })
+}
+
 export default client;

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,7 @@ let client = sanityClient
 
 if (typeof sanityClient.withConfig === 'function') {
   client = sanityClient.withConfig({
-    apiVersion: "v1"
+    apiVersion: "1"
   })
 }
 


### PR DESCRIPTION
<img width="2032" alt="Screen Shot 2021-06-25 at 11 10 19" src="https://user-images.githubusercontent.com/38528/123487079-1d7c7700-d5c2-11eb-901a-00f0a05a3983.png">

If you had a `reference` field on your document and an editor selected this field as a selected column, an exception would be thrown until the document was refetched with that field. Fix is to avoid rendering `SanityPreview` until the `value` is set.