### PR TITLE
feat: add basic search functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1729,6 +1729,7 @@
       "version": "7.15.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
       "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -3842,6 +3843,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.0.tgz",
       "integrity": "sha512-3GsbOoDYteFShlrBTKzI2Eii4vPg/jAf7LXRIn0WQePKlmhpkV0KoTMuawA7gZJkrbPrZGwv9IEAfIWaOaQK8w==",
+      "dev": true,
       "dependencies": {
         "classnames": "*"
       }
@@ -21522,6 +21524,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
       "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -22062,7 +22065,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -28278,6 +28282,7 @@
       "version": "7.15.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
       "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -29999,6 +30004,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.0.tgz",
       "integrity": "sha512-3GsbOoDYteFShlrBTKzI2Eii4vPg/jAf7LXRIn0WQePKlmhpkV0KoTMuawA7gZJkrbPrZGwv9IEAfIWaOaQK8w==",
+      "dev": true,
       "requires": {
         "classnames": "*"
       }
@@ -43889,6 +43895,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
       "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"
       }
@@ -44304,7 +44311,8 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.5",

--- a/super-pane/create-super-pane.tsx
+++ b/super-pane/create-super-pane.tsx
@@ -28,6 +28,8 @@ import {
   ControlsIcon,
 } from '@sanity/icons';
 import styles from './styles.module.css';
+import SearchField from './search-field';
+import FieldToSearchFor from './search-field/FieldToSearchFor';
 
 function parentHasClass(el: HTMLElement | null, className: string): boolean {
   if (!el) return false;
@@ -40,19 +42,22 @@ function createSuperPane(typeName: string, S: any) {
   const selectColumns = createEmitter();
   const refresh = createEmitter();
 
+  const fieldsToChooseFrom = schemaType.fields.map((field: any) => ({ name: field.name, title: field.type.title }))
+
   function SuperPane() {
     const router = useRouter();
     const [pageSize, setPageSize] = useState(25);
     const [columnSelectorOpen, setColumnSelectorOpen] = useState(false);
     const [selectedColumns, setSelectedColumns] = useState(new Set<string>());
     const [selectedIds, setSelectedIds] = useState(new Set<string>());
-
+    const [selectedFieldToSearchFor, setSelectedFieldToSearchFor] = useState<FieldToSearchFor>(fieldsToChooseFrom[0])
     const containerRef = useRef<HTMLDivElement>(null);
 
     const client = usePaginatedClient({
       typeName,
       pageSize,
       selectedColumns,
+      selectedFieldToSearchFor
     });
 
     useEffect(() => {
@@ -106,7 +111,14 @@ function createSuperPane(typeName: string, S: any) {
               />
             </div>
           </div>
-
+          <div>
+            <SearchField
+              searchCallback={client.setUserQuery}
+              currentField={selectedFieldToSearchFor}
+              fieldsToChooseFrom={fieldsToChooseFrom}
+              onFieldSelected={setSelectedFieldToSearchFor}
+            />
+          </div>
           <div className={styles.tableWrapper}>
             <div
               className={classNames(styles.loadingOverlay, {
@@ -320,6 +332,8 @@ function createSuperPane(typeName: string, S: any) {
                   <option value={25}>25</option>
                   <option value={50}>50</option>
                   <option value={100}>100</option>
+                  <option value={250}>250</option>
+                  <option value={500}>500</option>
                 </Select>
               </div>
             </label>
@@ -332,7 +346,7 @@ function createSuperPane(typeName: string, S: any) {
               mode="bleed"
             />
             <Label>
-              {client.page + 1}&nbsp;/&nbsp;{client.totalPages}
+              {client.totalPages === 0 ? 0 : client.page + 1}&nbsp;/&nbsp;{client.totalPages}
             </Label>
             <Button
               fontSize={1}

--- a/super-pane/search-field/FieldToSearchFor.ts
+++ b/super-pane/search-field/FieldToSearchFor.ts
@@ -1,0 +1,4 @@
+export default interface FieldToSearchFor {
+  name: string, 
+  title: string
+}

--- a/super-pane/search-field/index.tsx
+++ b/super-pane/search-field/index.tsx
@@ -1,0 +1,47 @@
+import { TextInput } from '@sanity/ui'
+import React, { useEffect, useState } from 'react'
+import FieldToSearchFor from './FieldToSearchFor';
+import SelectFieldToSearchFor from './select-field-to-search-for'
+import styles from './styles.module.css';
+
+interface SearchFieldProps {
+  searchCallback: (userQuery: string) => void
+  fieldsToChooseFrom: FieldToSearchFor[],
+  currentField: FieldToSearchFor,
+  onFieldSelected: (field: FieldToSearchFor) => void
+}
+
+let timeout: NodeJS.Timeout
+
+const SearchField: React.FC<SearchFieldProps> = ({ searchCallback, currentField, fieldsToChooseFrom, onFieldSelected }) => {
+  const [userQuery, setUserQuery] = useState('')
+
+  useEffect(() => {
+    if (timeout) clearTimeout(timeout)
+    if (!userQuery.length) return searchCallback('')
+    timeout = setTimeout(() => {
+      searchCallback(userQuery)
+    }, 700)
+    return () => clearTimeout(timeout)
+  }, [userQuery, searchCallback])
+
+  return <div className={styles.searchField}>
+    <TextInput
+      fontSize={[2, 2, 3, 4]}
+      onChange={(event) =>
+        setUserQuery(event.currentTarget.value)
+      }
+      padding={[3, 3, 4]}
+      placeholder="Search"
+      value={userQuery}
+      className={styles.searchInput}
+    />
+    <SelectFieldToSearchFor
+      currentField={currentField}
+      onFieldSelected={onFieldSelected}
+      fieldsToChooseFrom={fieldsToChooseFrom}
+    />
+  </div>
+}
+
+export default SearchField

--- a/super-pane/search-field/select-field-to-search-for.tsx
+++ b/super-pane/search-field/select-field-to-search-for.tsx
@@ -1,0 +1,34 @@
+import { MenuButton, Button, Menu, MenuItem } from '@sanity/ui';
+import React from 'react';
+import FieldToSearchFor from './FieldToSearchFor';
+
+interface SelectFieldToSearchForProps {
+  currentField: FieldToSearchFor,
+  fieldsToChooseFrom: FieldToSearchFor[],
+  onFieldSelected: (field: FieldToSearchFor) => void
+}
+
+const SelectFieldToSearchFor: React.FC<SelectFieldToSearchForProps> = ({ currentField, onFieldSelected, fieldsToChooseFrom }) => {
+
+    return (
+      <MenuButton
+        button={<Button text={currentField.title} />}
+        id="select-field-to-search-for"
+        menu={(
+          <Menu>
+            {fieldsToChooseFrom.map((field) => (
+              <MenuItem 
+                key={`fieldToSearchForOption - ${field.name}`} 
+                text={field.title} 
+                onClick={() => onFieldSelected(field)} 
+              />
+            ))}
+          </Menu>
+        )}
+        placement="left"
+        popover={{portal: true}}
+      />
+    );
+};
+
+export default SelectFieldToSearchFor;

--- a/super-pane/search-field/styles.module.css
+++ b/super-pane/search-field/styles.module.css
@@ -1,0 +1,4 @@
+.searchField {
+  width: 100%;
+  display: flex;
+}


### PR DESCRIPTION
### This PR introduces basic search functionality by doing a simple string matching for a given field.

Was a bit unsure about the naming convention for stuff I introduced, as I normally would have called it something related to query. However, since we're adding a "query" to an already defined query, I tried to stay away from calling the variables something with query.

Haven't contributed that much to open source before, so let me know if there is anything I should change. Have realized it probably should have been called custom filter instead of search functionality?