### PR TITLE
feat: move projectId to env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 public
 .DS_Store
+
+.env.development

--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ After this is done grab the project ID:
 cat ./temp-movie-project/sanity.json | grep projectId
 ```
 
-Copy and paste the `projectId` into the root `sanity.json` and then delete the `temp-movie-project` folder.
+Then you create a .env.development file for development:
+
+```
+echo SANITY_STUDIO_API_PROJECT_ID="ENTER_PROJECT_ID" > .env.development
+```
+
+Finally delete the `temp-movie-project` folder.
 
 ### Start the dev server
 

--- a/sanity.json
+++ b/sanity.json
@@ -4,7 +4,7 @@
     "name": "example-project"
   },
   "api": {
-    "projectId": "vs7c9lm7",
+    "projectId": "",
     "dataset": "production"
   },
   "plugins": [


### PR DESCRIPTION
### This PR improves the dev experience by moving the projectId to an .env file

Not a big problem, but makes the developing experience better by moving the projectId to an .env file, so you don't have to change the sanity.json every time.

Requires the SANITY_STUDIO_API_PROJECT_ID to be set on vercel for the example project.