### PR TITLE
feat: add support for custom column and cells in table

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ export default () =>
     ]);
 ```
 
+### Custom columns (optional):
+The SuperPane supports custom queries and column cells. A custom column consists of a title, name and type. Optionally, you can prodide it with a query and/or custom compoment.
+Example is show in [structure.js](./structure.js)
+
+
 ## Local development
 
 Here is the first time setup for this lib:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "sanity-super-pane",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
@@ -1729,6 +1730,7 @@
       "version": "7.15.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
       "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -3842,6 +3844,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.0.tgz",
       "integrity": "sha512-3GsbOoDYteFShlrBTKzI2Eii4vPg/jAf7LXRIn0WQePKlmhpkV0KoTMuawA7gZJkrbPrZGwv9IEAfIWaOaQK8w==",
+      "dev": true,
       "dependencies": {
         "classnames": "*"
       }
@@ -16569,6 +16572,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21522,6 +21530,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
       "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -22062,7 +22071,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -28278,6 +28288,7 @@
       "version": "7.15.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
       "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -29999,6 +30010,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.0.tgz",
       "integrity": "sha512-3GsbOoDYteFShlrBTKzI2Eii4vPg/jAf7LXRIn0WQePKlmhpkV0KoTMuawA7gZJkrbPrZGwv9IEAfIWaOaQK8w==",
+      "dev": true,
       "requires": {
         "classnames": "*"
       }
@@ -43889,6 +43901,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz",
       "integrity": "sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"
       }
@@ -44304,7 +44317,8 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "sanity-super-pane",
-  "version": "0.0.0",
+  "name": "@fnc/sanity-super-pane",
+  "version": "0.0.15",
   "description": "",
   "keywords": [
     "sanity"

--- a/structure.js
+++ b/structure.js
@@ -1,9 +1,26 @@
 import S from '@sanity/desk-tool/structure-builder';
+import React from 'react'
 import { createSuperPane } from './super-pane';
+
+const customColumns = [
+  {
+    title: 'Title 2',
+    name: 'title2',
+    type: 'string',
+    query: "title"
+  },
+  {
+    title: 'Cast Members',
+    name: 'castMembers',
+    type: 'number',
+    query: "count(castMembers)",
+    component: ({ castMembers }) => <div style={{ color: 'green' }}>{castMembers}</div>
+  }
+]
 
 export default () =>
   S.list()
     .title('Base')
     .items([
-      S.listItem().title('Normal List').child(createSuperPane('movie', S)),
+      S.listItem().title('Normal List').child(createSuperPane('movie', S, customColumns)),
     ]);

--- a/super-pane/cell/index.tsx
+++ b/super-pane/cell/index.tsx
@@ -2,14 +2,31 @@ import React from 'react';
 import SanityPreview from 'part:@sanity/base/preview';
 import blockContentToString from '../block-content-to-string';
 import styles from './styles.module.css';
+import { Field } from '../types/Field';
+import { Badge } from '@sanity/ui';
 
 interface Props {
-  field: any;
+  field: Field;
   value: any;
 }
 
 function Cell({ field, value }: Props) {
-  switch (field.type.name) {
+  if (field.component) {
+    const props = { [field.name]: value }
+    return <td key={field.name}>
+      <field.component {...props} />
+    </td>
+  }
+  switch (field.type) {
+    case 'boolean':
+      return <td key={field.name}>
+        <Badge
+          size={1}
+          tone={value ? 'positive' : 'caution'}
+        >
+          {value?.toString()}
+        </Badge>
+      </td>
     case 'string':
     case 'number': {
       return <td key={field.name}>{value}</td>;

--- a/super-pane/column-selector/index.tsx
+++ b/super-pane/column-selector/index.tsx
@@ -1,29 +1,28 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import { Dialog, Checkbox, Button } from '@sanity/ui';
 import { nanoid } from 'nanoid';
-import schema from 'part:@sanity/base/schema';
 import styles from './styles.module.css';
+import { Field } from '../types/Field';
 
 interface Props {
   typeName: string;
   open: boolean;
   onClose: () => void;
-  onSelect: (selectedColumns: Set<string>) => void;
-  initiallySelectedColumns: Set<string>;
+  onSelect: (selectedColumns: Map<string, Field>) => void;
+  initiallySelectedColumns: Map<string, Field>;
+  fields: Map<string, Field>
 }
 
 function ColumnSelector({
   open,
   onClose,
   onSelect,
-  typeName,
   initiallySelectedColumns,
+  fields,
 }: Props) {
-  const schemaType = schema.get(typeName);
   const [selectedColumns, setSelectedColumns] = useState(
     initiallySelectedColumns,
   );
-
   useEffect(() => {
     if (open) {
       setSelectedColumns(initiallySelectedColumns);
@@ -63,47 +62,44 @@ function ColumnSelector({
               className={styles.checkbox}
               checked={selectedColumns.has('_updatedAt')}
               onChange={() => {
-                setSelectedColumns((set) => {
-                  const nextSet = new Set(set);
+                setSelectedColumns((map) => {
+                  const nextMap = new Map(map);
 
-                  if (set.has('_updatedAt')) {
-                    nextSet.delete('_updatedAt');
+                  if (map.has('_updatedAt')) {
+                    nextMap.delete('_updatedAt');
                   } else {
-                    nextSet.add('_updatedAt');
+                    nextMap.set('_updatedAt', { title: 'Updated at', name: '_updatedAt', type: 'number' });
                   }
 
-                  return nextSet;
+                  return nextMap;
                 });
               }}
             />
             <span>Updated At</span>
           </label>
         </li>
-        {schemaType.fields.map((i: any) => {
-          const fieldName: string = i.name;
-          const title: string = i.type.title;
-
+        {Array.from(fields.values()).map((field) => {
           return (
-            <li key={fieldName}>
+            <li key={field.name}>
               <label className={styles.label}>
                 <Checkbox
                   className={styles.checkbox}
-                  checked={selectedColumns.has(fieldName)}
+                  checked={selectedColumns.has(field.name)}
                   onChange={() => {
-                    setSelectedColumns((set) => {
-                      const nextSet = new Set(set);
+                    console.log(field)
+                    setSelectedColumns((map) => {
+                      const nextMap = new Map(map);
 
-                      if (set.has(fieldName)) {
-                        nextSet.delete(fieldName);
+                      if (map.has(field.name)) {
+                        nextMap.delete(field.name);
                       } else {
-                        nextSet.add(fieldName);
+                        nextMap.set(field.name, field);
                       }
-
-                      return nextSet;
+                      return nextMap;
                     });
                   }}
                 />
-                <span>{title}</span>
+                <span>{field.title}</span>
               </label>
             </li>
           );

--- a/super-pane/create-super-pane.tsx
+++ b/super-pane/create-super-pane.tsx
@@ -70,7 +70,7 @@ function createSuperPane(typeName: string, S: any, customFields: Field[] = []) {
       typeName,
       pageSize,
       selectedColumns,
-      searchField: selectedSearchField,
+      searchField: localStorage.getItem("super_pane_key"),
     });
 
     useEffect(() => {

--- a/super-pane/create-super-pane.tsx
+++ b/super-pane/create-super-pane.tsx
@@ -63,7 +63,7 @@ function createSuperPane(typeName: string, S: any, customFields: Field[] = []) {
     const [selectedColumns, setSelectedColumns] = useState(customFieldsMap);
     const [selectedIds, setSelectedIds] = useState(new Set<string>());
     const [selectedSearchField, setSelectedSearchField] = useState<string | undefined>(searchableFields.length ? searchableFields[0].name : undefined)
-    const [showSearch, setShowSearch] = useState(false);
+    const [showSearch, setShowSearch] = useState(true);
     const containerRef = useRef<HTMLDivElement>(null);
 
     const client = usePaginatedClient({
@@ -88,6 +88,7 @@ function createSuperPane(typeName: string, S: any, customFields: Field[] = []) {
     const atLeastOneSelected = client.results.some((i) =>
       selectedIds.has(i._normalizedId)
     );
+
     const allSelected = client.results.every((i) =>
       selectedIds.has(i._normalizedId)
     );

--- a/super-pane/search-field/index.tsx
+++ b/super-pane/search-field/index.tsx
@@ -41,8 +41,8 @@ function SearchField({
 
       <div className={styles.searchSelect}>
         <Select
-          value={currentField || undefined}
-          onChange={(e) => onFieldSelected(e.currentTarget.value)}
+          value={localStorage.getItem("super_pane_key") || undefined}
+          onChange={(e) => localStorage.setItem("super_pane_key", e.currentTarget.value)}
         >
           {searchableFields.map((field) => (
             <option key={field.name} value={field.name}>

--- a/super-pane/search-field/index.tsx
+++ b/super-pane/search-field/index.tsx
@@ -1,17 +1,18 @@
 import { TextInput, Select } from '@sanity/ui';
 import React, { useEffect, useState } from 'react';
+import { Field } from '../types/Field';
 import styles from './styles.module.css';
 
 interface Props {
-  fieldsToChooseFrom: Array<{ name: string; title: string }>;
-  currentField: string | null;
+  currentField?: string;
   onSearch: (userQuery: string) => void;
   onFieldSelected: (field: string) => void;
+  searchableFields: Field[]
 }
 
 function SearchField({
   currentField,
-  fieldsToChooseFrom,
+  searchableFields,
   onSearch,
   onFieldSelected,
 }: Props) {
@@ -43,7 +44,7 @@ function SearchField({
           value={currentField || undefined}
           onChange={(e) => onFieldSelected(e.currentTarget.value)}
         >
-          {fieldsToChooseFrom.map((field) => (
+          {searchableFields.map((field) => (
             <option key={field.name} value={field.name}>
               {field.title}
             </option>

--- a/super-pane/types/Field.ts
+++ b/super-pane/types/Field.ts
@@ -1,0 +1,7 @@
+export interface Field {
+  title: string,
+  name: string,
+  type: 'string' | 'number' | 'blockContent' | 'datetime' | 'date' | 'array' | string
+  query?: string
+  component?: React.FC<{[id: string]: any}>
+}

--- a/super-pane/use-paginated-client.ts
+++ b/super-pane/use-paginated-client.ts
@@ -18,7 +18,7 @@ const removeDraftPrefix = (s: string) =>
 interface Params {
   typeName: string;
   pageSize: number;
-  searchField: string | undefined;
+  searchField: string | undefined | null;
   selectedColumns: Map<string, Field>;
 }
 


### PR DESCRIPTION
### This PR introduces custom columns/cells.

With this PR it's possible to define custom columns. It's also possible to add a custom component for the cell. If no component has been provided, it will fall back to the standard component for that field type.

The structure for a field have been updated to:

```js
const customColumns = [
  {
    title: 'Title 2',
    name: 'title2',
    type: 'string',
    query: "title"
  },
  {
    title: 'Cast Members',
    name: 'castMembers',
    type: 'number',
    query: "count(castMembers)",
    component: ({ castMembers }) => <div style={{ color: 'green' }}>{castMembers}</div>
  }
]

export default () =>
  S.list()
    .title('Base')
    .items([
      S.listItem().title('Normal List').child(createSuperPane('movie', S, customColumns)),
    ]);

```