### PR TITLE
feat:(index) add case for boolean field

### DIFF
--- a/super-pane/cell/index.tsx
+++ b/super-pane/cell/index.tsx
@@ -58,6 +58,22 @@ function Cell({ field, fieldPath, value }: Props) {
         </td>
       );
     }
+    case 'boolean': {
+      if (value == undefined){
+        return (
+          <td key={fieldPath}>
+            {''}
+          </td>
+        );
+      } 
+      else {
+        return (
+          <td key={fieldPath}>
+            {value == true ? 'true' : 'false'}
+          </td>
+        );
+      }
+    }
     default: {
       return (
         <td key={fieldPath}>


### PR DESCRIPTION
I noticed that when I have a boolean field and I include it in the pane, I get "Untitled" if the field is true, otherwise I get blank.  

This commit makes it render "true", "false" or leaves it blank if it is not defined. 