### PR TITLE
fix: add menu item to create document

### DIFF
--- a/super-pane/create-super-pane.tsx
+++ b/super-pane/create-super-pane.tsx
@@ -33,6 +33,7 @@ import {
   SpinnerIcon,
   ControlsIcon,
   SearchIcon,
+  AddIcon
 } from '@sanity/icons';
 import styles from './styles.module.css';
 import SearchField from './search-field';
@@ -491,6 +492,7 @@ function createSuperPane(typeName: string) {
     menuItems: S.documentTypeList(typeName)
       .menuItems(
         [
+          S.menuItem().title('Add').icon(AddIcon).intent({type: 'create', params: {type: typeName, template: typeName}}).showAsAction(true),
           S.menuItem().title('Refresh').icon(SyncIcon).action(refresh.notify),
           S.menuItem().title('Search').icon(SearchIcon).action(search.notify),
           S.menuItem()


### PR DESCRIPTION
Adding ability to create docs from the Super Pane menu. Seems to be missing in latest builds (maybe it wasn't there in the first place? my memory is fuzzy!). Should fix [Issue #34 ](https://github.com/ricokahler/sanity-super-pane/issues/63).
Thank you!